### PR TITLE
Add config options to specify bytes ID thresholds

### DIFF
--- a/src/backup_command.rs
+++ b/src/backup_command.rs
@@ -50,6 +50,8 @@ pub const ERROR_CODE_WRITING_DESTINATION_FAILED: ErrorCode = 3;
 
 pub struct BackupCommand {
     pub date_time: String,
+    bytes_id_threshold_min: i64,
+    bytes_id_threshold_max: i64,
     processed_count: i64,
     count: i32,
 }
@@ -58,6 +60,8 @@ impl BackupCommand {
     pub fn new() -> Self {
         Self {
             date_time: "".to_string(),
+            bytes_id_threshold_min: 0,
+            bytes_id_threshold_max: 100 * 1024 * 1024,
             processed_count: 0,
             count: 0,
         }
@@ -83,6 +87,14 @@ impl BackupCommand {
         } else {
             config = Config::new();
         }
+        self.bytes_id_threshold_min = match config.bytes_id_threshold_min {
+            Some(min) => min,
+            None => 0,
+        };
+        self.bytes_id_threshold_max = match config.bytes_id_threshold_max {
+            Some(max) => max,
+            None => 0,
+        };
 
         let mut producer = FilePathProducer::new(&config.source_path);
         let mut done = false;
@@ -134,8 +146,7 @@ impl BackupCommand {
         let mut bytes: Option<Vec<u8>> = None;
         let id: String;
         let file_size = metadata.len();
-        // TODO: Add parameters to config.
-        if file_size >= 10 * 1024 && file_size <= 100 * 1024 {
+        if file_size >= (self.bytes_id_threshold_min as u64) && file_size <= (self.bytes_id_threshold_max as u64) {
             bytes = match fs::read(path_buf.clone()) {
                 Ok(bytes) => Some(bytes),
                 Err(_) => return Err(Error::new(ERROR_ID, ERROR_CODE_READING_SOURCE_FAILED)),

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,12 +25,16 @@ use serde::Deserialize;
 #[derive(Deserialize)]
 pub struct Config {
     pub source_path: String,
+    pub bytes_id_threshold_min: Option<i64>,
+    pub bytes_id_threshold_max: Option<i64>,
 }
 
 impl Config {
     pub fn new() -> Self {
         Self {
             source_path: "".to_string(),
+            bytes_id_threshold_min: Some(0),
+            bytes_id_threshold_max: Some(100 * 1024 * 1024),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,5 +61,29 @@ mod tests {
             },
         };
         assert_eq!(config.source_path, "/a/b/c".to_string());
+
+        let serialized = "{ \"source_path\": \"/a/b/c\", \"bytes_id_threshold_min\": 123 }";
+        let config: Config = match serde_json::from_str(&serialized) {
+            Ok(config) => config,
+            Err(_) => {
+                assert!(false);
+
+                Config::new()
+            },
+        };
+        assert_eq!(config.source_path, "/a/b/c".to_string());
+        assert_eq!(config.bytes_id_threshold_min, Some(123));
+
+        let serialized = "{ \"source_path\": \"/a/b/c\", \"bytes_id_threshold_max\": 456 }";
+        let config: Config = match serde_json::from_str(&serialized) {
+            Ok(config) => config,
+            Err(_) => {
+                assert!(false);
+
+                Config::new()
+            },
+        };
+        assert_eq!(config.source_path, "/a/b/c".to_string());
+        assert_eq!(config.bytes_id_threshold_max, Some(456));
     }
 }


### PR DESCRIPTION
Added config options to specify bytes ID thresholds.
This closes #57.
