### PR TITLE
Improve console outputs when executing backup command

### DIFF
--- a/src/backup_command.rs
+++ b/src/backup_command.rs
@@ -132,6 +132,8 @@ impl BackupCommand {
             }
         }
 
+        println!("{} object(s) added.", self.added_count);
+
         Ok(())
     }
 


### PR DESCRIPTION
Improved console outputs when executing backup command.
This closes #75.
