### PR TITLE
Remove bytes mode object ID calculation

### DIFF
--- a/src/backup_command.rs
+++ b/src/backup_command.rs
@@ -172,34 +172,21 @@ impl BackupCommand {
         let mut bytes: Option<Vec<u8>> = None;
         let id: String;
         let file_size = metadata.len();
-        if file_size >= (self.bytes_id_threshold_min as u64)
-            && file_size <= (self.bytes_id_threshold_max as u64)
-        {
-            bytes = match fs::read(path_buf.clone()) {
-                Ok(bytes) => Some(bytes),
-                Err(_) => return Err(Error::new(ERROR_ID, ERROR_CODE_READING_SOURCE_FAILED)),
-            };
-            let mut id_bytes = b"b,".to_vec();
-            id_bytes = [id_bytes, bytes.clone().unwrap()].concat();
-            // println!("id_bytes.len(): {}", id_bytes.len());
-            id = object_id(&id_bytes);
-        } else {
-            let mut modified: u64 = 0;
-            let result = metadata.modified();
+        let mut modified: u64 = 0;
+        let result = metadata.modified();
+        if result.is_ok() {
+            let result = result.unwrap().duration_since(SystemTime::UNIX_EPOCH);
             if result.is_ok() {
-                let result = result.unwrap().duration_since(SystemTime::UNIX_EPOCH);
-                if result.is_ok() {
-                    modified = result.unwrap().as_secs();
-                }
+                modified = result.unwrap().as_secs();
             }
-            let string = format!(
-                "p,{},{},{}",
-                path_buf.to_string_lossy().to_string(),
-                modified,
-                file_size
-            );
-            id = object_id(&string.as_bytes().to_vec());
         }
+        let string = format!(
+            "p,{},{},{}",
+            path_buf.to_string_lossy().to_string(),
+            modified,
+            file_size
+        );
+        id = object_id(&string.as_bytes().to_vec());
 
         let exists = match store.exists(&id) {
             Ok(exists) => exists,

--- a/src/backup_command.rs
+++ b/src/backup_command.rs
@@ -53,8 +53,6 @@ pub struct BackupCommand {
     pub name: String,
     executing: DateTime<Local>,
     destination_path: String,
-    bytes_id_threshold_min: i64,
-    bytes_id_threshold_max: i64,
     excluded_directories: Vec<String>,
     processed_count: i64,
     added_count: i64,
@@ -67,8 +65,6 @@ impl BackupCommand {
             name: "".to_string(),
             executing: Local::now(),
             destination_path: ".".to_string(),
-            bytes_id_threshold_min: 0,
-            bytes_id_threshold_max: 100 * 1024 * 1024,
             excluded_directories: vec![],
             processed_count: 0,
             added_count: 0,
@@ -97,14 +93,6 @@ impl BackupCommand {
         } else {
             config = Config::new();
         }
-        self.bytes_id_threshold_min = match config.bytes_id_threshold_min {
-            Some(min) => min,
-            None => 0,
-        };
-        self.bytes_id_threshold_max = match config.bytes_id_threshold_max {
-            Some(max) => max,
-            None => 0,
-        };
         self.excluded_directories = match config.excluded_directories {
             Some(directories) => directories,
             None => vec![],

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,8 +25,6 @@ use serde::Deserialize;
 #[derive(Deserialize)]
 pub struct Config {
     pub source_path: String,
-    pub bytes_id_threshold_min: Option<i64>,
-    pub bytes_id_threshold_max: Option<i64>,
     pub excluded_directories: Option<Vec<String>>,
 }
 
@@ -34,8 +32,6 @@ impl Config {
     pub fn new() -> Self {
         Self {
             source_path: "".to_string(),
-            bytes_id_threshold_min: Some(0),
-            bytes_id_threshold_max: Some(100 * 1024 * 1024),
             excluded_directories: Some(vec![]),
         }
     }
@@ -63,30 +59,6 @@ mod tests {
             }
         };
         assert_eq!(config.source_path, "/a/b/c".to_string());
-
-        let serialized = "{ \"source_path\": \"/a/b/c\", \"bytes_id_threshold_min\": 123 }";
-        let config: Config = match serde_json::from_str(&serialized) {
-            Ok(config) => config,
-            Err(_) => {
-                assert!(false);
-
-                Config::new()
-            }
-        };
-        assert_eq!(config.source_path, "/a/b/c".to_string());
-        assert_eq!(config.bytes_id_threshold_min, Some(123));
-
-        let serialized = "{ \"source_path\": \"/a/b/c\", \"bytes_id_threshold_max\": 456 }";
-        let config: Config = match serde_json::from_str(&serialized) {
-            Ok(config) => config,
-            Err(_) => {
-                assert!(false);
-
-                Config::new()
-            }
-        };
-        assert_eq!(config.source_path, "/a/b/c".to_string());
-        assert_eq!(config.bytes_id_threshold_max, Some(456));
 
         let serialized = "{ \"source_path\": \"/a/b/c\", \"excluded_directories\": [ \"d\" ] }";
         let config: Config = match serde_json::from_str(&serialized) {


### PR DESCRIPTION
Removed bytes mode object ID calculation.
This closes #87.
