### PR TITLE
Remove old implementation for GcCommand

### DIFF
--- a/src/gc_command.rs
+++ b/src/gc_command.rs
@@ -172,30 +172,6 @@ impl GcCommand {
 
         Ok(())
     }
-
-    fn backup_paths(&self) -> Result<Vec<String>> {
-        let path = self.destination_path.pushed("Backups");
-        let read_dir = match fs::read_dir(&path) {
-            Ok(read_dir) => read_dir,
-            Err(_) => return Err(Error::new(ERROR_ID, ERROR_CODE_FINDING_BACKUP_FAILED)),
-        };
-        let mut backup_paths: Vec<String> = Vec::new();
-        for result in read_dir {
-            if result.is_ok() {
-                let entry = result.unwrap();
-                let path = entry.path();
-                let result = entry.metadata();
-                if result.is_ok() {
-                    let metadata = result.unwrap();
-                    if metadata.is_dir() && !metadata.is_symlink() {
-                        backup_paths.push(String::from_path(&path));
-                    }
-                }
-            }
-        }
-
-        Ok(backup_paths)
-    }
 }
 
 #[cfg(test)]

--- a/src/gc_command.rs
+++ b/src/gc_command.rs
@@ -25,7 +25,6 @@ use std::fs;
 use crate::commons::ConvertPath;
 use crate::commons::OperatePath;
 use crate::entry::Entry;
-use crate::error;
 use crate::error::Error;
 use crate::error::ErrorCode;
 use crate::error::ErrorId;
@@ -33,20 +32,16 @@ use crate::error::Result;
 use crate::file_path_producer;
 use crate::file_path_producer::FilePathProducer;
 use crate::object_store::Attributes;
-use crate::object_store::MarkingResult;
-use crate::object_store::ObjectStore;
 
 pub const ERROR_ID: ErrorId = "gc_command";
 
 #[allow(dead_code)]
 pub const ERROR_CODE_GENERAL: ErrorCode = 0;
 pub const ERROR_CODE_FINDING_BACKUP_FAILED: ErrorCode = 1;
-pub const ERROR_CODE_PROCESSING_ENTRY_FAILED: ErrorCode = 2;
-pub const ERROR_CODE_PROCESSING_OBJECT_FAILED: ErrorCode = 3;
+pub const ERROR_CODE_PROCESSING_OBJECT_FAILED: ErrorCode = 2;
 
 pub struct GcCommand {
     destination_path: String,
-    store: ObjectStore,
     backup_paths: Vec<String>,
     processed_count: i64,
     removed_count: i64,
@@ -57,7 +52,6 @@ impl GcCommand {
     pub fn new() -> Self {
         Self {
             destination_path: ".".to_string(),
-            store: ObjectStore::new(&"Objects"),
             backup_paths: Vec::new(),
             processed_count: 0,
             removed_count: 0,
@@ -111,24 +105,6 @@ impl GcCommand {
                 }
             }
         }
-
-        Ok(())
-    }
-
-    pub fn execute_old(&mut self) -> Result<()> {
-        let path = self.destination_path.pushed("Objects");
-        self.store = ObjectStore::new(&path);
-        let backup_paths = match self.backup_paths() {
-            Ok(backup_paths) => backup_paths,
-            Err(error) => return Err(error),
-        };
-        for path in backup_paths {
-            println!("Processing backup: {}", path);
-            if let Err(error) = self.process_backup(&path) {
-                println!("Processing backup {} failed. error: {}", path, error);
-            }
-        }
-        self.store.sweep()?;
 
         Ok(())
     }
@@ -193,57 +169,6 @@ impl GcCommand {
             println!("Warning: Removing {} failed.", attributes_path);
         }
         self.removed_count += 1;
-
-        Ok(())
-    }
-
-    fn process_backup(&mut self, path: &str) -> Result<()> {
-        let mut producer = FilePathProducer::new(&path);
-        let mut done = false;
-        while !done {
-            let option = match producer.next() {
-                Ok(path) => Some(path),
-                Err(error) => {
-                    if error.id == file_path_producer::ERROR_ID
-                        && error.code == file_path_producer::ERROR_CODE_PRODUCING_FINISHED
-                    {
-                        done = true;
-                    }
-                    // TODO: Displaying errors would be needed.
-
-                    None
-                }
-            };
-            if let Some(produced_path) = option {
-                let entry_path = path.pushed(&produced_path);
-                if let Err(error) = self.process_entry(&entry_path) {
-                    println!("Processing entry {} failed. error: {}", entry_path, error);
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    fn process_entry(&mut self, path: &str) -> Result<()> {
-        if self.count == 0 {
-            // println!("Processing ({}, {}): {}", self.processed_count, self.marked_count, path);
-        }
-        self.count += 1;
-        self.count %= 100;
-        let string = match fs::read_to_string(path) {
-            Ok(string) => string,
-            Err(_) => return Err(Error::new(ERROR_ID, ERROR_CODE_PROCESSING_ENTRY_FAILED)),
-        };
-        let entry: Entry = match serde_json::from_str(&string) {
-            Ok(entry) => entry,
-            Err(_) => return Err(Error::new(ERROR_ID, ERROR_CODE_PROCESSING_ENTRY_FAILED)),
-        };
-        let result = self.store.mark(&entry.id)?;
-        self.processed_count += 1;
-        if result == MarkingResult::Marked {
-            // self.marked_count += 1;
-        }
 
         Ok(())
     }

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -156,7 +156,6 @@ mod tests {
     use std::fs;
     use tempdir::TempDir;
 
-    use crate::object_store;
     use crate::object_store::Attributes;
     use crate::object_store::ObjectStore;
 
@@ -236,95 +235,5 @@ mod tests {
 
         let exists = store.exists(&id).unwrap();
         assert_eq!(exists, true);
-    }
-
-    #[test]
-    fn object_is_markable() {
-        let Ok(temp_dir) = TempDir::new("test") else {
-            panic!();
-        };
-        let path = temp_dir.path().join("Objects");
-        if let Err(_) = fs::create_dir_all(&path) {
-            panic!();
-        }
-        let mut store = ObjectStore::new(&path);
-
-        let id = "0102030405060708".to_string();
-        let bytes: Vec<u8> = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
-        let attribute = Attributes::new("", 0);
-        let Ok(_) = store.add(&id, &bytes, &attribute) else {
-            panic!();
-        };
-
-        let Ok(_) = store.mark(&id) else {
-            panic!();
-        };
-    }
-
-    #[test]
-    fn object_is_sweepable() {
-        let Ok(temp_dir) = TempDir::new("test") else {
-            panic!();
-        };
-        let path = temp_dir.path().join("Objects");
-        if let Err(_) = fs::create_dir_all(&path) {
-            panic!();
-        }
-        let mut store = ObjectStore::new(&path);
-
-        let id = "0102030405060708".to_string();
-        let bytes: Vec<u8> = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
-        let attribute = Attributes::new("", 0);
-        let Ok(_) = store.add(&id, &bytes, &attribute) else {
-            panic!();
-        };
-
-        let Ok(_) = store.mark(&id) else {
-            panic!();
-        };
-
-        let Ok(_) = store.sweep() else {
-            panic!();
-        };
-        let Ok(_) = store.bytes(&id) else {
-            panic!();
-        };
-
-        let Ok(_) = store.sweep() else {
-            panic!();
-        };
-        let Err(_) = store.bytes(&id) else {
-            panic!();
-        };
-    }
-
-    #[test]
-    fn marked_objects_are_shrinkable() {
-        let Ok(temp_dir) = TempDir::new("test") else {
-            panic!();
-        };
-        let path = temp_dir.path().join("Objects");
-        if let Err(_) = fs::create_dir_all(&path) {
-            panic!();
-        }
-        let mut store = ObjectStore::new(&path);
-
-        store
-            .marked_objects
-            .insert("ffffffffffffffff".to_string(), 1);
-        assert_eq!(store.marked_objects.len(), 1);
-        store.shrink_marked_objects();
-        assert_eq!(store.marked_objects.len(), 0);
-
-        for i in 0..object_store::MARKED_OBJECTS_MAX {
-            let id = format!("{:x}", i);
-            store.marked_objects.insert(id, 1);
-        }
-        assert_eq!(store.marked_objects.len(), object_store::MARKED_OBJECTS_MAX);
-        store.shrink_marked_objects();
-        assert_eq!(
-            store.marked_objects.len(),
-            object_store::MARKED_OBJECTS_MAX / 2
-        );
     }
 }

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -22,19 +22,14 @@
 
 use serde_derive::Deserialize;
 use serde_derive::Serialize;
-use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 
-use crate::commons::ConvertPath;
-use crate::commons::OperatePath;
 use crate::error::Error;
 use crate::error::ErrorCode;
 use crate::error::ErrorId;
 use crate::error::Result;
-use crate::file_path_producer;
-use crate::file_path_producer::FilePathProducer;
 
 pub const ERROR_ID: ErrorId = "object_store";
 
@@ -42,17 +37,7 @@ pub const ERROR_ID: ErrorId = "object_store";
 pub const ERROR_CODE_GENERAL: ErrorCode = 0;
 pub const ERROR_CODE_READING_OBJECT_FAILED: ErrorCode = 1;
 pub const ERROR_CODE_WRITING_OBJECT_FAILED: ErrorCode = 2;
-pub const ERROR_CODE_MARKING_OBJECT_FAILED: ErrorCode = 3;
 pub const ERROR_CODE_WRITING_ATTTIBUTE_FAILED: ErrorCode = 4;
-
-const MARKED_OBJECTS_MAX: usize = 4000000;
-
-#[derive(PartialEq)]
-pub enum MarkingResult {
-    Marked,
-    AlreadyMarked,
-    NotFound,
-}
 
 // TODO: Move to attributes.rs.
 #[derive(Serialize, Deserialize, Clone)]
@@ -72,7 +57,6 @@ impl Attributes {
 
 pub struct ObjectStore {
     path: PathBuf,
-    marked_objects: HashMap<String, i64>,
 }
 
 impl ObjectStore {
@@ -81,7 +65,6 @@ impl ObjectStore {
         path_buf.push(path);
         ObjectStore {
             path: path_buf,
-            marked_objects: HashMap::new(),
         }
     }
 
@@ -165,127 +148,6 @@ impl ObjectStore {
         };
 
         Ok(exists)
-    }
-
-    pub fn mark(&mut self, id: &str) -> Result<MarkingResult> {
-        if self.marked_objects.contains_key(id) {
-            *self.marked_objects.get_mut(id).unwrap() += 1;
-
-            return Ok(MarkingResult::AlreadyMarked);
-        }
-
-        let path1 = &id[0..2];
-        let path2 = &id[2..4];
-        let path3 = &id[4..6];
-        let path4 = &id[6..8];
-        let mut path = self.path.clone();
-        path.push(path1);
-        path.push(path2);
-        path.push(path3);
-        path.push(path4);
-        let mut object_path = path.clone();
-        object_path.push(id);
-        let file_name = id.to_string() + ".marked";
-        let mut mark_path = path.clone();
-        mark_path.push(&file_name);
-
-        let result: MarkingResult;
-        if mark_path.exists() {
-            result = MarkingResult::AlreadyMarked;
-        } else {
-            if let Err(_) = fs::write(mark_path, "") {
-                if object_path.exists() {
-                    return Err(Error::new(ERROR_ID, ERROR_CODE_MARKING_OBJECT_FAILED));
-                }
-
-                return Ok(MarkingResult::NotFound);
-            }
-
-            result = MarkingResult::Marked;
-        }
-
-        if self.marked_objects.len() > MARKED_OBJECTS_MAX {
-            self.shrink_marked_objects();
-        }
-        self.marked_objects.insert(id.to_string(), 1);
-
-        Ok(result)
-    }
-
-    pub fn sweep(&self) -> Result<()> {
-        let mut count: i32 = 0;
-        let mut producer = FilePathProducer::new(&String::from_path(&self.path));
-        let mut removed_count: i64 = 0;
-        let mut done = false;
-        while !done {
-            let option = match producer.next() {
-                Ok(path) => Some(path),
-                Err(error) => {
-                    if error.id == file_path_producer::ERROR_ID
-                        && error.code == file_path_producer::ERROR_CODE_PRODUCING_FINISHED
-                    {
-                        done = true;
-                    }
-
-                    None
-                }
-            };
-            if let Some(path) = option {
-                if path.rfind(".marked").is_none() {
-                    let mark_path = path.clone() + ".marked";
-                    let mark_path = String::from_path(&self.path).pushed(&mark_path);
-                    count += 1;
-                    count %= 100;
-                    if count == 0 {
-                        println!("Checking: {}", mark_path);
-                    }
-                    let exists = PathBuf::from(&mark_path).exists();
-                    if exists {
-                        if let Err(_) = fs::remove_file(&mark_path) {
-                            println!("Warning: removing mark file {} failed.", path);
-                        }
-                    } else {
-                        let object_path = String::from_path(&self.path).pushed(&path);
-                        if let Err(_) = fs::remove_file(&object_path) {
-                            println!("Warning: removing object {} failed.", object_path);
-                        }
-                        removed_count += 1;
-                    }
-                }
-            }
-        }
-        println!("{} object(s) removed.", removed_count);
-
-        Ok(())
-    }
-
-    fn shrink_marked_objects(&mut self) {
-        let count = self.marked_objects.len();
-        let mut sum: i64 = 0;
-        for (_, value) in &self.marked_objects {
-            sum += value;
-        }
-        let average = sum / (count as i64);
-
-        let mut removing_count = MARKED_OBJECTS_MAX / 2;
-        let mut keys: Vec<String> = Vec::new();
-        for key in self.marked_objects.keys() {
-            keys.push(key.clone());
-        }
-        for key in keys {
-            if self.marked_objects[&key] <= average {
-                self.marked_objects.remove(&key);
-                removing_count -= 1;
-                if removing_count <= 0 {
-                    break;
-                }
-            }
-        }
-
-        println!(
-            "marked_objects shrinked. len: {}",
-            self.marked_objects.len()
-        );
     }
 }
 


### PR DESCRIPTION
Removed old implementation for GcCommand.
This closes #89.
