### PR TITLE
Remove old OperatePath trait and rename OperatePath3 to new OperatePath trait

### DIFF
--- a/src/backup_command.rs
+++ b/src/backup_command.rs
@@ -38,7 +38,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::time::SystemTime;
 
 use crate::attributes::Attributes;
-use crate::commons::OperatePath3;
+use crate::commons::OperatePath;
 use crate::config::Config;
 use crate::entry::Entry;
 use crate::error::Error;

--- a/src/backup_store.rs
+++ b/src/backup_store.rs
@@ -22,7 +22,6 @@
 
 use std::fs;
 
-use crate::commons::OperatePath;
 use crate::commons::OperatePath3;
 use crate::error::Error;
 use crate::error::ErrorCode;

--- a/src/backup_store.rs
+++ b/src/backup_store.rs
@@ -22,7 +22,7 @@
 
 use std::fs;
 
-use crate::commons::OperatePath3;
+use crate::commons::OperatePath;
 use crate::error::Error;
 use crate::error::ErrorCode;
 use crate::error::ErrorId;

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -78,23 +78,12 @@ impl OperatePath3 for PathBuf {
 
 // TODO: Remove this.
 pub trait OperatePath {
-    fn directories(&self) -> String;
     fn file_name(&self) -> String;
     fn extension(&self) -> String;
     fn is_begun(&self, path: &str) -> bool;
 }
 
 impl OperatePath for str {
-    fn directories(&self) -> String {
-        let mut split: Vec<_> = self.split(path::MAIN_SEPARATOR_STR).collect();
-        if split.len() < 1 {
-            return "".to_string();
-        }
-        split.pop();
-
-        split.join(path::MAIN_SEPARATOR_STR)
-    }
-
     fn file_name(&self) -> String {
         let mut split: Vec<_> = self.split(path::MAIN_SEPARATOR_STR).collect();
         if split.len() < 1 {
@@ -129,17 +118,6 @@ mod tests {
     use camino::Utf8PathBuf;
 
     use crate::commons::OperatePath;
-
-    #[test]
-    fn directories_are_gettable() {
-        let path = "a/b/c/d.txt";
-        let directories = path.directories();
-        assert_eq!(directories, "a/b/c".to_string());
-
-        let path = "d.txt";
-        let directories = path.directories();
-        assert_eq!(directories, "".to_string());
-    }
 
     #[test]
     fn file_name_is_gettable() {

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -97,31 +97,10 @@ impl OperatePath3 for PathBuf {
 
 // TODO: Remove this.
 pub trait OperatePath {
-    fn file_name(&self) -> String;
-    fn extension(&self) -> String;
     fn is_begun(&self, path: &str) -> bool;
 }
 
 impl OperatePath for str {
-    fn file_name(&self) -> String {
-        let mut split: Vec<_> = self.split(path::MAIN_SEPARATOR_STR).collect();
-        if split.len() < 1 {
-            return "".to_string();
-        }
-
-        split.pop().unwrap().to_string()
-    }
-
-    fn extension(&self) -> String {
-        let file_name = self.file_name();
-        let mut split: Vec<_> = file_name.split(".").collect();
-        if split.len() < 2 {
-            return "".to_string();
-        }
-
-        split.pop().unwrap().to_string()
-    }
-
     fn is_begun(&self, path: &str) -> bool {
         // TODO: Improve implementation.
         if self.find(path) == Some(0) {
@@ -137,28 +116,6 @@ mod tests {
     use camino::Utf8PathBuf;
 
     use crate::commons::OperatePath;
-
-    #[test]
-    fn file_name_is_gettable() {
-        let path = "a/b/c/d.txt";
-        let file_name = path.file_name();
-        assert_eq!(file_name, "d.txt".to_string());
-
-        let path = "a.txt";
-        let file_name = path.file_name();
-        assert_eq!(file_name, "a.txt".to_string());
-    }
-
-    #[test]
-    fn extension_is_gettable() {
-        let path = "a/b/c/d.txt";
-        let extension = path.extension();
-        assert_eq!(extension, "txt".to_string());
-
-        let path = "a/b/c/d";
-        let extension = path.extension();
-        assert_eq!(extension, "".to_string());
-    }
 
     #[test]
     fn head_directries_are_checkable() {

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -27,6 +27,8 @@ use std::path::PathBuf;
 
 // TODO: Rename this.
 // TODO: Add tests.
+// TODO: Add to_string_easy().
+// TODO: directories() should be migrated to parent()?
 pub trait OperatePath3 {
     fn file_name_or_empty(&self) -> String;
     fn extension_or_empty(&self) -> String;

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -22,7 +22,6 @@
 
 use camino::Utf8PathBuf;
 use std::path;
-use std::path::Path;
 use std::path::PathBuf;
 
 // TODO: Rename this.

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -24,17 +24,16 @@ use camino::Utf8PathBuf;
 use std::path;
 use std::path::PathBuf;
 
-// TODO: Rename this.
 // TODO: Add tests.
 // TODO: Add to_string_easy().
 // TODO: directories() should be migrated to parent()?
-pub trait OperatePath3 {
+pub trait OperatePath {
     fn file_name_or_empty(&self) -> String;
     fn extension_or_empty(&self) -> String;
     fn directories(&self) -> String;
 }
 
-impl OperatePath3 for Utf8PathBuf {
+impl OperatePath for Utf8PathBuf {
     fn file_name_or_empty(&self) -> String {
         let file_name = match self.file_name() {
             Some(file_name) => file_name,
@@ -65,7 +64,7 @@ impl OperatePath3 for Utf8PathBuf {
     }
 }
 
-impl OperatePath3 for PathBuf {
+impl OperatePath for PathBuf {
     fn file_name_or_empty(&self) -> String {
         let file_name = match self.file_name() {
             Some(file_name) => file_name.to_string_lossy().to_string(),

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -97,5 +97,41 @@ impl OperatePath for PathBuf {
 
 #[cfg(test)]
 mod tests {
-    // TODO: Add tests for new OperatePath trait.
+    use camino::Utf8PathBuf;
+    use std::path::PathBuf;
+
+    use crate::commons::OperatePath;
+    
+    #[test]
+    fn file_name_is_gettable() {
+        let path = Utf8PathBuf::from("/a/b/c.txt");
+        let file_name = path.file_name_or_empty();
+        assert_eq!(file_name, "c.txt");
+
+        let path = PathBuf::from("/a/b/c.txt");
+        let file_name = path.file_name_or_empty();
+        assert_eq!(file_name, "c.txt");
+    }
+
+    #[test]
+    fn extension_is_gettable() {
+        let path = Utf8PathBuf::from("/a/b/c.txt");
+        let extension = path.extension_or_empty();
+        assert_eq!(extension, "txt");
+
+        let path = PathBuf::from("/a/b/c.txt");
+        let extension = path.extension_or_empty();
+        assert_eq!(extension, "txt");
+    }
+    
+    #[test]
+    fn directories_are_gettable() {
+        let path = Utf8PathBuf::from("/a/b/c.txt");
+        let directories = path.directories();
+        assert_eq!(directories, "/a/b");
+
+        let path = PathBuf::from("/a/b/c.txt");
+        let directories = path.directories();
+        assert_eq!(directories, "/a/b");
+    }
 }

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -29,6 +29,7 @@ use std::path::PathBuf;
 // TODO: Add tests.
 pub trait OperatePath3 {
     fn file_name_or_empty(&self) -> String;
+    fn extension_or_empty(&self) -> String;
     fn directories(&self) -> String;
 }
 
@@ -40,6 +41,15 @@ impl OperatePath3 for Utf8PathBuf {
         };
 
         file_name.to_string()
+    }
+
+    fn extension_or_empty(&self) -> String {
+        let extension = match self.extension() {
+            Some(extension) => extension,
+            None => return "".to_string(),
+        };
+
+        extension.to_string()
     }
 
     fn directories(&self) -> String {
@@ -62,6 +72,15 @@ impl OperatePath3 for PathBuf {
         };
 
         file_name
+    }
+
+    fn extension_or_empty(&self) -> String {
+        let extension = match self.extension() {
+            Some(extension) => extension.to_string_lossy().to_string(),
+            None => return "".to_string(),
+        };
+
+        extension
     }
 
     fn directories(&self) -> String {

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -96,32 +96,7 @@ impl OperatePath3 for PathBuf {
     }
 }
 
-// TODO: Remove this.
-pub trait OperatePath {
-    fn is_begun(&self, path: &str) -> bool;
-}
-
-impl OperatePath for str {
-    fn is_begun(&self, path: &str) -> bool {
-        // TODO: Improve implementation.
-        if self.find(path) == Some(0) {
-            return true;
-        }
-
-        false
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use camino::Utf8PathBuf;
-
-    use crate::commons::OperatePath;
-
-    #[test]
-    fn head_directries_are_checkable() {
-        let path = "a/b/c/d.txt";
-        assert_eq!(path.is_begun("a/b"), true);
-        assert_eq!(path.is_begun("a/c"), false);
-    }
+    // TODO: Add tests for new OperatePath trait.
 }

--- a/src/file_path_producer.rs
+++ b/src/file_path_producer.rs
@@ -20,6 +20,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+use camino::Utf8PathBuf;
 use std::fs;
 use std::path::Path;
 
@@ -99,9 +100,9 @@ impl FilePathProducer {
                                 self.file_paths.push(path);
                             } else if is_dir {
                                 let mut needed = true;
-                                let path1 = path[self.prefix_length..].to_string();
+                                let path1 = Utf8PathBuf::from(&path[self.prefix_length..].to_string());
                                 for directory in &self.excluded_directories {
-                                    if path1.is_begun(directory) {
+                                    if path1.starts_with(&directory) {
                                         needed = false;
 
                                         // TODO: Can we break here?

--- a/src/file_path_producer.rs
+++ b/src/file_path_producer.rs
@@ -103,6 +103,8 @@ impl FilePathProducer {
                                 for directory in &self.excluded_directories {
                                     if path1.is_begun(directory) {
                                         needed = false;
+
+                                        // TODO: Can we break here?
                                     }
                                 }
                                 if needed {

--- a/src/file_path_producer.rs
+++ b/src/file_path_producer.rs
@@ -24,7 +24,6 @@ use camino::Utf8PathBuf;
 use std::fs;
 use std::path::Path;
 
-use crate::commons::OperatePath;
 use crate::error::Error;
 use crate::error::ErrorCode;
 use crate::error::ErrorId;
@@ -133,11 +132,9 @@ impl FilePathProducer {
 
 #[cfg(test)]
 mod tests {
-    use camino::Utf8PathBuf;
     use std::fs;
     use tempdir::TempDir;
 
-    use crate::commons::OperatePath;
     use crate::file_path_producer;
     use crate::file_path_producer::FilePathProducer;
 

--- a/src/gc_command.rs
+++ b/src/gc_command.rs
@@ -28,6 +28,7 @@ use std::path::Path;
 
 use crate::backup_store::BackupStore;
 use crate::commons::OperatePath;
+use crate::commons::OperatePath3;
 use crate::entry::Entry;
 use crate::error::ErrorCode;
 use crate::error::ErrorId;
@@ -151,12 +152,12 @@ impl GcCommand {
     }
 
     fn process_unit(&mut self, index1: i32, index2: i32) -> Result<()> {
-        let path1 = format!("{:02x}", index1);
-        let path2 = format!("{:02x}", index2);
+        let directory1 = format!("{:02x}", index1);
+        let directory2 = format!("{:02x}", index2);
         let mut object_path = Utf8PathBuf::from(&self.destination_path);
         object_path.push("Objects");
-        object_path.push(&path1);
-        object_path.push(&path2);
+        object_path.push(&directory1);
+        object_path.push(&directory2);
         if !Path::new(&object_path).exists() {
             return Ok(());
         }
@@ -177,9 +178,12 @@ impl GcCommand {
             };
 
             if let Some(produced_path) = option {
-                if produced_path.extension() == "" {
-                    let mut path = Utf8PathBuf::from(&path1);
-                    path.push(&path2);
+                let path = Utf8PathBuf::from(&produced_path);
+                let extension = path.extension_or_empty();
+                let file_name = path.file_name_or_empty();
+                if extension == "" {
+                    let mut path = Utf8PathBuf::from(&directory1);
+                    path.push(&directory2);
                     path.push(&produced_path);
                     if let Err(error) = self.process_object(path.as_str()) {
                         println!(
@@ -188,9 +192,10 @@ impl GcCommand {
                         );
                     }
                     self.processed_count += 1;
-                    self.state.last_processed_id = produced_path.file_name();
+                    self.state.last_processed_id = file_name;
                 }
             }
+
         }
 
         Ok(())
@@ -207,7 +212,8 @@ impl GcCommand {
         self.count += 1;
         self.count %= 100;
 
-        let object_id = path.file_name();
+        let path1 = Utf8PathBuf::from(&path);
+        let object_id = path1.file_name_or_empty();
         let attributes = match object_store.attributes(&object_id) {
             Ok(attributes) => attributes,
             Err(error) => return Err(error),

--- a/src/gc_command.rs
+++ b/src/gc_command.rs
@@ -27,7 +27,6 @@ use std::fs;
 use std::path::Path;
 
 use crate::backup_store::BackupStore;
-use crate::commons::OperatePath;
 use crate::commons::OperatePath3;
 use crate::entry::Entry;
 use crate::error::ErrorCode;

--- a/src/gc_command.rs
+++ b/src/gc_command.rs
@@ -27,7 +27,7 @@ use std::fs;
 use std::path::Path;
 
 use crate::backup_store::BackupStore;
-use crate::commons::OperatePath3;
+use crate::commons::OperatePath;
 use crate::entry::Entry;
 use crate::error::ErrorCode;
 use crate::error::ErrorId;

--- a/src/get_command.rs
+++ b/src/get_command.rs
@@ -31,7 +31,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::time::Duration;
 use std::time::SystemTime;
 
-use crate::commons::OperatePath3;
+use crate::commons::OperatePath;
 use crate::entry::Entry;
 use crate::error::Error;
 use crate::error::ErrorCode;

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -26,7 +26,6 @@ use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::Write;
 
-use crate::commons::OperatePath3;
 use crate::attributes::Attributes;
 use crate::error::Error;
 use crate::error::ErrorCode;


### PR DESCRIPTION
Removed old OperatePath trait and renamed OperatePath3 to new OperatePath trait.
This closes #130.
