### PR TITLE
Rename from OperatePath::directories() to OperatePath::parent_or_empty()

### DIFF
--- a/src/backup_command.rs
+++ b/src/backup_command.rs
@@ -163,7 +163,7 @@ impl BackupCommand {
         }
         let path_buf = Utf8PathBuf::from(&path);
         let path_file_name = path_buf.file_name_or_empty();
-        let path_directries = path_buf.directories();
+        let path_directries = path_buf.parent_or_empty();
         self.count += 1;
         self.count %= 100;
         let mut path_buf = Utf8PathBuf::new();

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -167,6 +167,7 @@ impl OperatePath for Path {
 #[cfg(test)]
 mod tests {
     use camino::Utf8PathBuf;
+    use camino::Utf8Path;
     use std::path::Path;
     use std::path::PathBuf;
 
@@ -175,6 +176,10 @@ mod tests {
     #[test]
     fn file_name_is_gettable() {
         let path = Utf8PathBuf::from("/a/b/c.txt");
+        let file_name = path.file_name_or_empty();
+        assert_eq!(file_name, "c.txt");
+
+        let path = Utf8Path::new("/a/b/c.txt");
         let file_name = path.file_name_or_empty();
         assert_eq!(file_name, "c.txt");
 
@@ -193,6 +198,10 @@ mod tests {
         let extension = path.extension_or_empty();
         assert_eq!(extension, "txt");
 
+        let path = Utf8Path::new("/a/b/c.txt");
+        let extension = path.extension_or_empty();
+        assert_eq!(extension, "txt");
+
         let path = PathBuf::from("/a/b/c.txt");
         let extension = path.extension_or_empty();
         assert_eq!(extension, "txt");
@@ -203,8 +212,12 @@ mod tests {
     }
 
     #[test]
-    fn directories_are_gettable() {
+    fn parent_directories_are_gettable() {
         let path = Utf8PathBuf::from("/a/b/c.txt");
+        let string = path.to_string_easy();
+        assert_eq!(string, "/a/b/c.txt");
+
+        let path = Utf8Path::new("/a/b/c.txt");
         let string = path.to_string_easy();
         assert_eq!(string, "/a/b/c.txt");
 

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -20,8 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+use camino::Utf8Path;
 use camino::Utf8PathBuf;
-use std::path;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -29,6 +29,7 @@ use std::path::PathBuf;
 pub trait OperatePath {
     fn file_name_or_empty(&self) -> String;
     fn extension_or_empty(&self) -> String;
+    // TODO: Rename to parent_or_empty().
     fn directories(&self) -> String;
     fn to_string_easy(&self) -> String;
 }
@@ -53,14 +54,45 @@ impl OperatePath for Utf8PathBuf {
     }
 
     fn directories(&self) -> String {
-        let path = self.as_str().to_string();
-        let mut split: Vec<_> = path.split(path::MAIN_SEPARATOR_STR).collect();
-        if split.len() < 1 {
-            return "".to_string();
-        }
-        split.pop();
+        let parent = match self.parent() {
+            Some(parent) => parent,
+            None => return "".to_string(),
+        };
 
-        split.join(path::MAIN_SEPARATOR_STR)
+        parent.to_string_easy()
+    }
+
+    fn to_string_easy(&self) -> String {
+        self.as_str().to_string()
+    }
+}
+
+impl OperatePath for Utf8Path {
+    fn file_name_or_empty(&self) -> String {
+        let file_name = match self.file_name() {
+            Some(file_name) => file_name,
+            None => return "".to_string(),
+        };
+
+        file_name.to_string()
+    }
+
+    fn extension_or_empty(&self) -> String {
+        let extension = match self.extension() {
+            Some(extension) => extension,
+            None => return "".to_string(),
+        };
+
+        extension.to_string()
+    }
+
+    fn directories(&self) -> String {
+        let parent = match self.parent() {
+            Some(parent) => parent,
+            None => return "".to_string(),
+        };
+
+        parent.to_string_easy()
     }
 
     fn to_string_easy(&self) -> String {
@@ -88,14 +120,12 @@ impl OperatePath for PathBuf {
     }
 
     fn directories(&self) -> String {
-        let path = self.to_string_lossy().to_string();
-        let mut split: Vec<_> = path.split(path::MAIN_SEPARATOR_STR).collect();
-        if split.len() < 1 {
-            return "".to_string();
-        }
-        split.pop();
+        let parent = match self.parent() {
+            Some(parent) => parent,
+            None => return "".to_string(),
+        };
 
-        split.join(path::MAIN_SEPARATOR_STR)
+        parent.to_string_easy()
     }
 
     fn to_string_easy(&self) -> String {
@@ -123,14 +153,12 @@ impl OperatePath for Path {
     }
 
     fn directories(&self) -> String {
-        let path = self.to_string_lossy().to_string();
-        let mut split: Vec<_> = path.split(path::MAIN_SEPARATOR_STR).collect();
-        if split.len() < 1 {
-            return "".to_string();
-        }
-        split.pop();
+        let parent = match self.parent() {
+            Some(parent) => parent,
+            None => return "".to_string(),
+        };
 
-        split.join(path::MAIN_SEPARATOR_STR)
+        parent.to_string_easy()
     }
 
     fn to_string_easy(&self) -> String {

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -25,12 +25,10 @@ use camino::Utf8PathBuf;
 use std::path::Path;
 use std::path::PathBuf;
 
-// TODO: directories() should be migrated to parent()?
 pub trait OperatePath {
     fn file_name_or_empty(&self) -> String;
     fn extension_or_empty(&self) -> String;
-    // TODO: Rename to parent_or_empty().
-    fn directories(&self) -> String;
+    fn parent_or_empty(&self) -> String;
     fn to_string_easy(&self) -> String;
 }
 
@@ -53,7 +51,7 @@ impl OperatePath for Utf8PathBuf {
         extension.to_string()
     }
 
-    fn directories(&self) -> String {
+    fn parent_or_empty(&self) -> String {
         let parent = match self.parent() {
             Some(parent) => parent,
             None => return "".to_string(),
@@ -86,7 +84,7 @@ impl OperatePath for Utf8Path {
         extension.to_string()
     }
 
-    fn directories(&self) -> String {
+    fn parent_or_empty(&self) -> String {
         let parent = match self.parent() {
             Some(parent) => parent,
             None => return "".to_string(),
@@ -119,7 +117,7 @@ impl OperatePath for PathBuf {
         extension
     }
 
-    fn directories(&self) -> String {
+    fn parent_or_empty(&self) -> String {
         let parent = match self.parent() {
             Some(parent) => parent,
             None => return "".to_string(),
@@ -152,7 +150,7 @@ impl OperatePath for Path {
         extension
     }
 
-    fn directories(&self) -> String {
+    fn parent_or_empty(&self) -> String {
         let parent = match self.parent() {
             Some(parent) => parent,
             None => return "".to_string(),

--- a/src/get_command.rs
+++ b/src/get_command.rs
@@ -132,7 +132,7 @@ impl Task for GetCommand {
                     gotten_path.push(&self.limited_directory);
                 }
                 gotten_path.push(&path);
-                let directories = gotten_path.directories();
+                let directories = gotten_path.parent_or_empty();
                 match fs::create_dir_all(&directories) {
                     Ok(_) => (),
                     // TODO: Skipping file that writing is failed may be needed.


### PR DESCRIPTION
Renamed from OperatePath::directories() to OperatePath::parent_or_empty().
This closes #135.
