### PR TITLE
Store existing object IDs for caching

### DIFF
--- a/src/backup_command.rs
+++ b/src/backup_command.rs
@@ -137,9 +137,6 @@ impl Task for BackupCommand {
             "{} object(s) added.",
             self.added_count.load(Ordering::Relaxed)
         );
-
-        let store1 = store.read().unwrap();
-        store1.test();
         
         Ok(())
     }

--- a/src/backup_command.rs
+++ b/src/backup_command.rs
@@ -138,6 +138,9 @@ impl Task for BackupCommand {
             self.added_count.load(Ordering::Relaxed)
         );
 
+        let store1 = store.read().unwrap();
+        store1.test();
+        
         Ok(())
     }
 }

--- a/src/backup_command.rs
+++ b/src/backup_command.rs
@@ -137,7 +137,7 @@ impl Task for BackupCommand {
             "{} object(s) added.",
             self.added_count.load(Ordering::Relaxed)
         );
-        
+
         Ok(())
     }
 }

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -44,6 +44,7 @@ pub const ERROR_CODE_READING_ATTTIBUTE_FAILED: ErrorCode = 4;
 pub const ERROR_CODE_WRITING_ATTTIBUTE_FAILED: ErrorCode = 5;
 pub const ERROR_CODE_REMOVING_ATTTIBUTE_FAILED: ErrorCode = 6;
 pub const ERROR_CODE_OBJECT_ALREADY_EXISTS: ErrorCode = 7;
+pub const ERROR_CODE_INVALID_OBJECT_ID: ErrorCode = 8;
 
 pub struct ObjectStore {
     path: String,
@@ -54,7 +55,7 @@ pub struct ObjectStore {
 impl ObjectStore {
     pub fn new(path: &str) -> Self {
         let mut existing_ids: Vec<Vec<String>> = Vec::new();
-        for i in 0..65536 {
+        for _ in 0..65536 {
             existing_ids.push(Vec::new());
         }
 
@@ -65,11 +66,24 @@ impl ObjectStore {
         }
     }
 
-    pub fn add(&self, id: &str, bytes: &Vec<u8>, attributes: &Attributes) -> Result<()> {
+    pub fn add(&mut self, id: &str, bytes: &Vec<u8>, attributes: &Attributes) -> Result<()> {
         let path1 = &id[0..2];
         let path2 = &id[2..4];
         let path3 = &id[4..6];
         let path4 = &id[6..8];
+        let Ok(index1) = u32::from_str_radix(path1, 16) else {
+            return Err(Error::new(ERROR_ID, ERROR_CODE_INVALID_OBJECT_ID));
+        };
+        let Ok(index2) = u32::from_str_radix(path2, 16) else {
+            return Err(Error::new(ERROR_ID, ERROR_CODE_INVALID_OBJECT_ID));
+        };
+        let index = (index1 * 0x100 + index2) as usize;
+        let ids = &mut self.existing_ids[index];
+        if ids.into_iter().position(|id1| {id1 == id}).is_some() {
+            return Ok(());
+        }
+        ids.push(id.to_string());
+
         let mut path = Utf8PathBuf::from(&self.path);
         path.push(path1);
         path.push(path2);
@@ -180,14 +194,16 @@ impl ObjectStore {
         let path2 = &id[2..4];
         let path3 = &id[4..6];
         let path4 = &id[6..8];
-        let result1 = path1.parse::<u32>();
-        let result2 = path2.parse::<u32>();
-        if result1.is_ok() && result2.is_ok() {
-            let index = (result1.unwrap() * 0x100 + result2.unwrap()) as usize;
-            let ids = &self.existing_ids[index];
-            if ids.into_iter().position(|id1| {id1 == id}).is_some() {
-                return Ok(true);
-            }
+        let Ok(index1) = u32::from_str_radix(path1, 16) else {
+            return Err(Error::new(ERROR_ID, ERROR_CODE_INVALID_OBJECT_ID));
+        };
+        let Ok(index2) = u32::from_str_radix(path2, 16) else {
+            return Err(Error::new(ERROR_ID, ERROR_CODE_INVALID_OBJECT_ID));
+        };
+        let index = (index1 * 0x100 + index2) as usize;
+        let ids = &self.existing_ids[index];
+        if ids.into_iter().position(|id1| {id1 == id}).is_some() {
+            return Ok(true);
         }
 
         let mut path = Utf8PathBuf::from(&self.path);
@@ -302,7 +318,7 @@ mod tests {
         if let Err(_) = fs::create_dir_all(&path) {
             panic!();
         }
-        let store = ObjectStore::new(&path.to_string_easy());
+        let mut store = ObjectStore::new(&path.to_string_easy());
 
         let id = "0102030405060708".to_string();
         let bytes: Vec<u8> = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
@@ -319,7 +335,7 @@ mod tests {
         if let Err(_) = fs::create_dir_all(&path) {
             panic!();
         }
-        let store = ObjectStore::new(&path.to_string_easy());
+        let mut store = ObjectStore::new(&path.to_string_easy());
 
         let id = "0102030405060708".to_string();
         let bytes: Vec<u8> = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
@@ -337,7 +353,7 @@ mod tests {
         if let Err(_) = fs::create_dir_all(&path) {
             panic!();
         }
-        let store = ObjectStore::new(&path.to_string_easy());
+        let mut store = ObjectStore::new(&path.to_string_easy());
 
         let id = "0102030405060708".to_string();
         let bytes: Vec<u8> = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
@@ -364,7 +380,7 @@ mod tests {
         if let Err(_) = fs::create_dir_all(&path) {
             panic!();
         }
-        let store = ObjectStore::new(&path.to_string_easy());
+        let mut store = ObjectStore::new(&path.to_string_easy());
 
         let id = "0102030405060708".to_string();
         let bytes: Vec<u8> = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
@@ -389,7 +405,7 @@ mod tests {
         if let Err(_) = fs::create_dir_all(&path) {
             panic!();
         }
-        let store = ObjectStore::new(&path.to_string_easy());
+        let mut store = ObjectStore::new(&path.to_string_easy());
 
         let id = "0102030405060708".to_string();
         let bytes: Vec<u8> = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -286,6 +286,12 @@ impl ObjectStore {
         }
         self.adding_file = None;
     }
+
+    pub fn test(&self) {
+        for i in 0..65536 {
+            println!("{}: {}", i, self.existing_ids[i].len());
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -286,12 +286,6 @@ impl ObjectStore {
         }
         self.adding_file = None;
     }
-
-    pub fn test(&self) {
-        for i in 0..65536 {
-            println!("{}: {}", i, self.existing_ids[i].len());
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -48,13 +48,20 @@ pub const ERROR_CODE_OBJECT_ALREADY_EXISTS: ErrorCode = 7;
 pub struct ObjectStore {
     path: String,
     adding_file: Option<File>,
+    existing_ids: Vec<Vec<String>>,
 }
 
 impl ObjectStore {
     pub fn new(path: &str) -> Self {
+        let mut existing_ids: Vec<Vec<String>> = Vec::new();
+        for i in 0..65536 {
+            existing_ids.push(Vec::new());
+        }
+
         ObjectStore {
             path: path.to_string(),
             adding_file: None,
+            existing_ids: existing_ids,
         }
     }
 
@@ -173,6 +180,16 @@ impl ObjectStore {
         let path2 = &id[2..4];
         let path3 = &id[4..6];
         let path4 = &id[6..8];
+        let result1 = path1.parse::<u32>();
+        let result2 = path2.parse::<u32>();
+        if result1.is_ok() && result2.is_ok() {
+            let index = (result1.unwrap() * 0x100 + result2.unwrap()) as usize;
+            let ids = &self.existing_ids[index];
+            if ids.into_iter().position(|id1| {id1 == id}).is_some() {
+                return Ok(true);
+            }
+        }
+
         let mut path = Utf8PathBuf::from(&self.path);
         path.push(path1);
         path.push(path2);


### PR DESCRIPTION
Stored existing object IDs for caching.
This closes #146.
