### PR TITLE
Add backgrpund execution support for Task trait

### DIFF
--- a/src/background_executer.rs
+++ b/src/background_executer.rs
@@ -29,6 +29,7 @@ use crate::error::Error;
 use crate::error::ErrorCode;
 use crate::error::ErrorId;
 use crate::error::Result;
+use crate::task;
 use crate::task::Task;
 
 pub const ERROR_ID: ErrorId = "backup_command";
@@ -73,6 +74,39 @@ impl Task for BackgroundExecuter {
         self.handle = Some(handle);
 
         Ok(())
+    }
+
+    /// Attempts to execute a task or operation in the background.
+    ///
+    /// **Note:** This method currently returns an error, explicitly indicating that
+    /// background execution is not supported by the current implementation.
+    /// It serves as a placeholder or an unimplemented feature.
+    ///
+    /// # Errors
+    ///
+    /// This method will always return an `Err(Error)` with `task::ERROR_ID` and
+    /// `task::ERROR_CODE_NOT_SUPPORTED`, as background execution is not
+    /// currently implemented or supported.
+    ///
+    /// # Returns
+    ///
+    /// A `Result<()>` which will always be `Err` in the current implementation,
+    /// signalling the lack of background execution support.
+    fn execute_in_background(&mut self) -> Result<()> {
+        Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED))
+    }
+
+    /// Joins the current execution context with this task, waiting for the task to complete.
+    ///
+    /// **Note:** This method is currently not supported and will always return an error indicating
+    /// `NOT_SUPPORTED`.
+    ///
+    /// # Returns
+    ///
+    /// An `Err` containing an `Error` with `ERROR_ID` and `ERROR_CODE_NOT_SUPPORTED`, as this
+    /// operation is not implemented.
+    fn join(&mut self) -> Result<()> {
+        Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED))
     }
 }
 

--- a/src/backup_command.rs
+++ b/src/backup_command.rs
@@ -52,6 +52,7 @@ use crate::file_path_producer;
 use crate::file_path_producer::FilePathProducer;
 use crate::object_adder::ObjectAdder;
 use crate::object_store::ObjectStore;
+use crate::task;
 use crate::task::Task;
 
 pub const ERROR_ID: ErrorId = "backup_command";
@@ -153,6 +154,39 @@ impl Task for BackupCommand {
         );
 
         Ok(())
+    }
+
+    /// Attempts to execute a task or operation in the background.
+    ///
+    /// **Note:** This method currently returns an error, explicitly indicating that
+    /// background execution is not supported by the current implementation.
+    /// It serves as a placeholder or an unimplemented feature.
+    ///
+    /// # Errors
+    ///
+    /// This method will always return an `Err(Error)` with `task::ERROR_ID` and
+    /// `task::ERROR_CODE_NOT_SUPPORTED`, as background execution is not
+    /// currently implemented or supported.
+    ///
+    /// # Returns
+    ///
+    /// A `Result<()>` which will always be `Err` in the current implementation,
+    /// signalling the lack of background execution support.
+    fn execute_in_background(&mut self) -> Result<()> {
+        Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED))
+    }
+
+    /// Joins the current execution context with this task, waiting for the task to complete.
+    ///
+    /// **Note:** This method is currently not supported and will always return an error indicating
+    /// `NOT_SUPPORTED`.
+    ///
+    /// # Returns
+    ///
+    /// An `Err` containing an `Error` with `ERROR_ID` and `ERROR_CODE_NOT_SUPPORTED`, as this
+    /// operation is not implemented.
+    fn join(&mut self) -> Result<()> {
+        Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED))
     }
 }
 

--- a/src/backup_remover.rs
+++ b/src/backup_remover.rs
@@ -310,6 +310,5 @@ mod tests {
         let mut remover = BackupRemover::new();
         remover.set_destination_path(&ntm_path.to_string_easy());
         remover.execute().unwrap();
-        remover.join().unwrap();
     }
 }

--- a/src/backup_remover.rs
+++ b/src/backup_remover.rs
@@ -83,13 +83,32 @@ impl Task for BackupRemover {
     /// - `Ok(())` if the thread was successfully spawned.
     fn execute(&mut self) -> Result<()> {
         let private = self.private.clone();
+        let result = main(&private);
+
+        result
+    }
+
+    fn execute_in_background(&mut self) -> Result<()> {
+        let private = self.private.clone();
         self.join_handle = Some(thread::spawn(move || {
             let result = main(&private);
 
             result
         }));
 
-        Ok(())
+        Ok(())        
+    }
+
+    fn join(&mut self) -> Result<()> {
+        let handle = self.join_handle.take();
+        let Some(handle) = handle else {
+            return Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED));
+        };
+        let Ok(result) = handle.join() else {
+            return Err(Error::new(task::ERROR_ID, task::ERROR_CODE_PANICKED));
+        };
+
+        result
     }
 }
 
@@ -122,6 +141,7 @@ impl BackupRemover {
     ///     In this case, an error with `task::ERROR_ID` and `task::ERROR_CODE_NOT_SUPPORTED` is returned.
     ///   - The joined task/thread panicked during its execution.
     ///     In this case, an error with `task::ERROR_ID` and `task::ERROR_CODE_PANICED` is returned.
+    /*
     pub fn join(&mut self) -> Result<()> {
         let handle = self.join_handle.take();
         let Some(handle) = handle else {
@@ -133,6 +153,7 @@ impl BackupRemover {
 
         result
     }
+    */
 
     /// Sets the destination path for the operation managed by this instance.
     ///

--- a/src/backup_remover.rs
+++ b/src/backup_remover.rs
@@ -88,6 +88,24 @@ impl Task for BackupRemover {
         result
     }
 
+    /// Spawns a new thread to execute a background task.
+    ///
+    /// This method clones the internal `private` state and moves it into a new
+    /// thread. The `main` function is then called within this new thread using
+    /// the cloned `private` state.
+    ///
+    /// A `JoinHandle` for the newly created thread is stored in `self.join_handle`,
+    /// allowing the caller to later wait for the completion of the background
+    /// task using the `join` method.
+    ///
+    /// This method returns `Ok(())` immediately after successfully spawning the
+    /// thread, without waiting for the background task to complete. Any errors
+    /// occurring within the background task itself will be captured by the
+    /// `JoinHandle` and can be retrieved when `join` is called.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if the thread was successfully spawned.
     fn execute_in_background(&mut self) -> Result<()> {
         let private = self.private.clone();
         self.join_handle = Some(thread::spawn(move || {
@@ -99,6 +117,15 @@ impl Task for BackupRemover {
         Ok(())        
     }
 
+    /// Spawns a new thread to execute the background task.
+    ///
+    /// This method clones the `private` state of the current object and moves it into a new thread.
+    /// The `main` function is then called within this new thread, using the cloned `private` state.
+    /// The `JoinHandle` for this thread is stored internally, allowing the task's completion
+    /// and result to be awaited using the `join` method.
+    ///
+    /// # Returns
+    /// - `Ok(())` if the background thread is successfully spawned.
     fn join(&mut self) -> Result<()> {
         let handle = self.join_handle.take();
         let Some(handle) = handle else {
@@ -125,35 +152,6 @@ impl BackupRemover {
             private: Arc::new(RwLock::new(Private::new())),
         }
     }
-
-    /// Joins the underlying thread, waiting for it to complete.
-    ///
-    /// This method attempts to take and consume the internal `JoinHandle`,
-    /// meaning it can only be called once successfully for a given instance.
-    /// It blocks the current thread until the associated task/thread has finished execution.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(())` if the task completed successfully without panicking.
-    /// - `Err(Error)` if:
-    ///   - No `JoinHandle` is available within the `self` instance (e.g., the task has already been joined,
-    ///     not started, or the method was called without a valid handle).
-    ///     In this case, an error with `task::ERROR_ID` and `task::ERROR_CODE_NOT_SUPPORTED` is returned.
-    ///   - The joined task/thread panicked during its execution.
-    ///     In this case, an error with `task::ERROR_ID` and `task::ERROR_CODE_PANICED` is returned.
-    /*
-    pub fn join(&mut self) -> Result<()> {
-        let handle = self.join_handle.take();
-        let Some(handle) = handle else {
-            return Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED));
-        };
-        let Ok(result) = handle.join() else {
-            return Err(Error::new(task::ERROR_ID, task::ERROR_CODE_PANICKED));
-        };
-
-        result
-    }
-    */
 
     /// Sets the destination path for the operation managed by this instance.
     ///

--- a/src/backup_remover.rs
+++ b/src/backup_remover.rs
@@ -114,7 +114,7 @@ impl Task for BackupRemover {
             result
         }));
 
-        Ok(())        
+        Ok(())
     }
 
     /// Spawns a new thread to execute the background task.

--- a/src/clean_command.rs
+++ b/src/clean_command.rs
@@ -52,14 +52,14 @@ impl Task for CleanCommand {
     fn execute(&mut self) -> Result<()> {
         let mut remover = BackupRemover::new();
         remover.set_destination_path(&self.destination_path);
-        remover.execute()?;
+        remover.execute_in_background()?;
 
         let mut collector = GarbageCollector::new();
         collector.set_destination_path(&self.destination_path);
         if let Some(limited_count) = self.limited_count {
             collector.set_limited_count(limited_count);
         }
-        collector.execute()?;
+        collector.execute_in_background()?;
 
         if let Err(error) = remover.join() {
             println!("Removing backups failed. error {}", error);

--- a/src/clean_command.rs
+++ b/src/clean_command.rs
@@ -21,10 +21,12 @@
  */
 
 use crate::backup_remover::BackupRemover;
+use crate::error::Error;
 use crate::error::ErrorCode;
 use crate::error::ErrorId;
 use crate::error::Result;
 use crate::garbage_collector::GarbageCollector;
+use crate::task;
 use crate::task::Task;
 
 #[allow(dead_code)]
@@ -67,6 +69,39 @@ impl Task for CleanCommand {
         }
 
         Ok(())
+    }
+
+    /// Attempts to execute a task or operation in the background.
+    ///
+    /// **Note:** This method currently returns an error, explicitly indicating that
+    /// background execution is not supported by the current implementation.
+    /// It serves as a placeholder or an unimplemented feature.
+    ///
+    /// # Errors
+    ///
+    /// This method will always return an `Err(Error)` with `task::ERROR_ID` and
+    /// `task::ERROR_CODE_NOT_SUPPORTED`, as background execution is not
+    /// currently implemented or supported.
+    ///
+    /// # Returns
+    ///
+    /// A `Result<()>` which will always be `Err` in the current implementation,
+    /// signalling the lack of background execution support.
+    fn execute_in_background(&mut self) -> Result<()> {
+        Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED))
+    }
+
+    /// Joins the current execution context with this task, waiting for the task to complete.
+    ///
+    /// **Note:** This method is currently not supported and will always return an error indicating
+    /// `NOT_SUPPORTED`.
+    ///
+    /// # Returns
+    ///
+    /// An `Err` containing an `Error` with `ERROR_ID` and `ERROR_CODE_NOT_SUPPORTED`, as this
+    /// operation is not implemented.
+    fn join(&mut self) -> Result<()> {
+        Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED))
     }
 }
 

--- a/src/entry_saver.rs
+++ b/src/entry_saver.rs
@@ -29,6 +29,7 @@ use crate::error::Error;
 use crate::error::ErrorCode;
 use crate::error::ErrorId;
 use crate::error::Result;
+use crate::task;
 use crate::task::Task;
 
 pub const ERROR_ID: ErrorId = "entry_saver";
@@ -66,6 +67,39 @@ impl Task for EntrySaver {
         }
 
         Ok(())
+    }
+
+    /// Attempts to execute a task or operation in the background.
+    ///
+    /// **Note:** This method currently returns an error, explicitly indicating that
+    /// background execution is not supported by the current implementation.
+    /// It serves as a placeholder or an unimplemented feature.
+    ///
+    /// # Errors
+    ///
+    /// This method will always return an `Err(Error)` with `task::ERROR_ID` and
+    /// `task::ERROR_CODE_NOT_SUPPORTED`, as background execution is not
+    /// currently implemented or supported.
+    ///
+    /// # Returns
+    ///
+    /// A `Result<()>` which will always be `Err` in the current implementation,
+    /// signalling the lack of background execution support.
+    fn execute_in_background(&mut self) -> Result<()> {
+        Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED))
+    }
+
+    /// Joins the current execution context with this task, waiting for the task to complete.
+    ///
+    /// **Note:** This method is currently not supported and will always return an error indicating
+    /// `NOT_SUPPORTED`.
+    ///
+    /// # Returns
+    ///
+    /// An `Err` containing an `Error` with `ERROR_ID` and `ERROR_CODE_NOT_SUPPORTED`, as this
+    /// operation is not implemented.
+    fn join(&mut self) -> Result<()> {
+        Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED))
     }
 }
 

--- a/src/garbage_collector.rs
+++ b/src/garbage_collector.rs
@@ -96,13 +96,22 @@ pub struct GarbageCollector {
 }
 
 impl Task for GarbageCollector {
+    /// Executes the main operational logic by leveraging the instance's private data.
+    ///
+    /// This method first accesses and clones the `private` field from the instance (`self.private`).
+    /// It then invokes the `main` function, passing a reference to this cloned private data.
+    /// The `Result` returned by the `main` function is directly propagated and returned by this method.
+    ///
+    /// # Returns
+    /// A `Result<()>` which represents the outcome of the `main` function's execution.
+    /// Returns `Ok(())` on successful completion of the `main` function, or an `Err`
+    /// containing details if the operation within `main` fails.
     fn execute(&mut self) -> Result<()> {
         let private = self.private.clone();
         let result = main(&private);
 
         result
     }
-
 
     /// Spawns a new thread to execute the main application logic.
     ///
@@ -134,6 +143,25 @@ impl Task for GarbageCollector {
         Ok(())
     }
 
+    /// Waits for the previously spawned task or thread to complete and returns its result.
+    ///
+    /// This method takes ownership of the `join_handle` from the instance. If no
+    /// handle is present (meaning no task was spawned or it was already joined),
+    /// an error indicating an unsupported operation is returned. If the joined task
+    /// panics, an error indicating a panic is returned.
+    ///
+    /// # Errors
+    ///
+    /// * `Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED)`: If there is no
+    ///   `join_handle` available to join (e.g., the task was not spawned, or it was
+    ///   already joined and the handle consumed).
+    /// * `Error::new(task::ERROR_ID, task::ERROR_CODE_PANICKED)`: If the underlying
+    ///   task or thread being joined panics during its execution.
+    ///
+    /// # Returns
+    ///
+    /// A `Result<()>` representing the outcome of the joined task. `Ok(())` on successful
+    /// completion, or an `Err` if the task itself returned an error.
     fn join(&mut self) -> Result<()> {
         let handle = self.join_handle.take();
         let Some(handle) = handle else {

--- a/src/garbage_collector.rs
+++ b/src/garbage_collector.rs
@@ -96,6 +96,14 @@ pub struct GarbageCollector {
 }
 
 impl Task for GarbageCollector {
+    fn execute(&mut self) -> Result<()> {
+        let private = self.private.clone();
+        let result = main(&private);
+
+        result
+    }
+
+
     /// Spawns a new thread to execute the main application logic.
     ///
     /// This method initializes a new background thread to perform the core operations.
@@ -115,7 +123,7 @@ impl Task for GarbageCollector {
     /// returns a `JoinHandle` directly and does not typically fail to *spawn* the thread
     /// in a way that returns a `Result`. The `Result<()>` return type might be present
     /// for future error handling or to satisfy a trait's signature.
-    fn execute(&mut self) -> Result<()> {
+    fn execute_in_background(&mut self) -> Result<()> {
         let private = self.private.clone();
         self.join_handle = Some(thread::spawn(move || {
             let result = main(&private);
@@ -124,6 +132,18 @@ impl Task for GarbageCollector {
         }));
 
         Ok(())
+    }
+
+    fn join(&mut self) -> Result<()> {
+        let handle = self.join_handle.take();
+        let Some(handle) = handle else {
+            return Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED));
+        };
+        let Ok(result) = handle.join() else {
+            return Err(Error::new(task::ERROR_ID, task::ERROR_CODE_PANICKED));
+        };
+
+        result
     }
 }
 
@@ -158,6 +178,7 @@ impl GarbageCollector {
     ///     panicked during execution.
     /// *   `Err` (propagated from the thread's execution) if the `main` function executed
     ///     within the thread returned an `Err`.
+    /*
     pub fn join(&mut self) -> Result<()> {
         let handle = self.join_handle.take();
         let Some(handle) = handle else {
@@ -169,6 +190,7 @@ impl GarbageCollector {
 
         result
     }
+    */
 
     /// Sets the destination path where processed files or data will be stored.
     ///

--- a/src/garbage_collector.rs
+++ b/src/garbage_collector.rs
@@ -496,6 +496,5 @@ mod tests {
         let mut collector = GarbageCollector::new();
         collector.set_destination_path(&ntm_path.to_string_easy());
         collector.execute().unwrap();
-        collector.join().unwrap();
     }
 }

--- a/src/garbage_collector.rs
+++ b/src/garbage_collector.rs
@@ -192,34 +192,6 @@ impl GarbageCollector {
         }
     }
 
-    /// Waits for the spawned thread to complete and returns its result.
-    ///
-    /// This method consumes the `join_handle` associated with the thread.
-    /// It should only be called once after `execute` has been called.
-    ///
-    /// # Errors
-    ///
-    /// *   `Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED))` if `join` is called
-    ///     without a thread having been spawned (i.e., `join_handle` is `None`). This can happen
-    ///     if `execute` was not called or if `join` was called multiple times.
-    /// *   `Err(Error::new(task::ERROR_ID, task::ERROR_CODE_PANICED))` if the spawned thread
-    ///     panicked during execution.
-    /// *   `Err` (propagated from the thread's execution) if the `main` function executed
-    ///     within the thread returned an `Err`.
-    /*
-    pub fn join(&mut self) -> Result<()> {
-        let handle = self.join_handle.take();
-        let Some(handle) = handle else {
-            return Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED));
-        };
-        let Ok(result) = handle.join() else {
-            return Err(Error::new(task::ERROR_ID, task::ERROR_CODE_PANICKED));
-        };
-
-        result
-    }
-    */
-
     /// Sets the destination path where processed files or data will be stored.
     ///
     /// This operation acquires a write lock on the internal state to update the path.

--- a/src/get_command.rs
+++ b/src/get_command.rs
@@ -40,6 +40,7 @@ use crate::error::Result;
 use crate::file_path_producer;
 use crate::file_path_producer::FilePathProducer;
 use crate::object_store::ObjectStore;
+use crate::task;
 use crate::task::Task;
 
 pub const ERROR_ID: ErrorId = "get_command";
@@ -162,6 +163,39 @@ impl Task for GetCommand {
         println!("{} file(s) gotten.", self.processed_count);
 
         Ok(())
+    }
+
+    /// Attempts to execute a task or operation in the background.
+    ///
+    /// **Note:** This method currently returns an error, explicitly indicating that
+    /// background execution is not supported by the current implementation.
+    /// It serves as a placeholder or an unimplemented feature.
+    ///
+    /// # Errors
+    ///
+    /// This method will always return an `Err(Error)` with `task::ERROR_ID` and
+    /// `task::ERROR_CODE_NOT_SUPPORTED`, as background execution is not
+    /// currently implemented or supported.
+    ///
+    /// # Returns
+    ///
+    /// A `Result<()>` which will always be `Err` in the current implementation,
+    /// signalling the lack of background execution support.
+    fn execute_in_background(&mut self) -> Result<()> {
+        Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED))
+    }
+
+    /// Joins the current execution context with this task, waiting for the task to complete.
+    ///
+    /// **Note:** This method is currently not supported and will always return an error indicating
+    /// `NOT_SUPPORTED`.
+    ///
+    /// # Returns
+    ///
+    /// An `Err` containing an `Error` with `ERROR_ID` and `ERROR_CODE_NOT_SUPPORTED`, as this
+    /// operation is not implemented.
+    fn join(&mut self) -> Result<()> {
+        Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED))
     }
 }
 

--- a/src/init_command.rs
+++ b/src/init_command.rs
@@ -27,6 +27,7 @@ use crate::error::Error;
 use crate::error::ErrorCode;
 use crate::error::ErrorId;
 use crate::error::Result;
+use crate::task;
 use crate::task::Task;
 
 pub const ERROR_ID: ErrorId = "init_command";
@@ -64,6 +65,39 @@ impl Task for InitCommand {
         // TODO: Create ntm.toml.
 
         Ok(())
+    }
+
+    /// Attempts to execute a task or operation in the background.
+    ///
+    /// **Note:** This method currently returns an error, explicitly indicating that
+    /// background execution is not supported by the current implementation.
+    /// It serves as a placeholder or an unimplemented feature.
+    ///
+    /// # Errors
+    ///
+    /// This method will always return an `Err(Error)` with `task::ERROR_ID` and
+    /// `task::ERROR_CODE_NOT_SUPPORTED`, as background execution is not
+    /// currently implemented or supported.
+    ///
+    /// # Returns
+    ///
+    /// A `Result<()>` which will always be `Err` in the current implementation,
+    /// signalling the lack of background execution support.
+    fn execute_in_background(&mut self) -> Result<()> {
+        Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED))
+    }
+
+    /// Joins the current execution context with this task, waiting for the task to complete.
+    ///
+    /// **Note:** This method is currently not supported and will always return an error indicating
+    /// `NOT_SUPPORTED`.
+    ///
+    /// # Returns
+    ///
+    /// An `Err` containing an `Error` with `ERROR_ID` and `ERROR_CODE_NOT_SUPPORTED`, as this
+    /// operation is not implemented.
+    fn join(&mut self) -> Result<()> {
+        Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED))
     }
 }
 

--- a/src/object_adder.rs
+++ b/src/object_adder.rs
@@ -36,6 +36,7 @@ use crate::error::ErrorId;
 use crate::error::Result;
 use crate::object_store;
 use crate::object_store::ObjectStore;
+use crate::task;
 use crate::task::Task;
 
 pub const ERROR_ID: ErrorId = "object_adder";
@@ -126,6 +127,39 @@ impl Task for ObjectAdder {
         self.added_count.fetch_add(1, Ordering::SeqCst);
 
         Ok(())
+    }
+
+    /// Attempts to execute a task or operation in the background.
+    ///
+    /// **Note:** This method currently returns an error, explicitly indicating that
+    /// background execution is not supported by the current implementation.
+    /// It serves as a placeholder or an unimplemented feature.
+    ///
+    /// # Errors
+    ///
+    /// This method will always return an `Err(Error)` with `task::ERROR_ID` and
+    /// `task::ERROR_CODE_NOT_SUPPORTED`, as background execution is not
+    /// currently implemented or supported.
+    ///
+    /// # Returns
+    ///
+    /// A `Result<()>` which will always be `Err` in the current implementation,
+    /// signalling the lack of background execution support.
+    fn execute_in_background(&mut self) -> Result<()> {
+        Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED))
+    }
+
+    /// Joins the current execution context with this task, waiting for the task to complete.
+    ///
+    /// **Note:** This method is currently not supported and will always return an error indicating
+    /// `NOT_SUPPORTED`.
+    ///
+    /// # Returns
+    ///
+    /// An `Err` containing an `Error` with `ERROR_ID` and `ERROR_CODE_NOT_SUPPORTED`, as this
+    /// operation is not implemented.
+    fn join(&mut self) -> Result<()> {
+        Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED))
     }
 }
 

--- a/src/remove_backup_command.rs
+++ b/src/remove_backup_command.rs
@@ -29,6 +29,7 @@ use crate::error::Error;
 use crate::error::ErrorCode;
 use crate::error::ErrorId;
 use crate::error::Result;
+use crate::task;
 use crate::task::Task;
 
 #[allow(dead_code)]
@@ -93,6 +94,39 @@ impl Task for RemoveBackupCommand {
         }
 
         Ok(())
+    }
+
+    /// Attempts to execute a task or operation in the background.
+    ///
+    /// **Note:** This method currently returns an error, explicitly indicating that
+    /// background execution is not supported by the current implementation.
+    /// It serves as a placeholder or an unimplemented feature.
+    ///
+    /// # Errors
+    ///
+    /// This method will always return an `Err(Error)` with `task::ERROR_ID` and
+    /// `task::ERROR_CODE_NOT_SUPPORTED`, as background execution is not
+    /// currently implemented or supported.
+    ///
+    /// # Returns
+    ///
+    /// A `Result<()>` which will always be `Err` in the current implementation,
+    /// signalling the lack of background execution support.
+    fn execute_in_background(&mut self) -> Result<()> {
+        Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED))
+    }
+
+    /// Joins the current execution context with this task, waiting for the task to complete.
+    ///
+    /// **Note:** This method is currently not supported and will always return an error indicating
+    /// `NOT_SUPPORTED`.
+    ///
+    /// # Returns
+    ///
+    /// An `Err` containing an `Error` with `ERROR_ID` and `ERROR_CODE_NOT_SUPPORTED`, as this
+    /// operation is not implemented.
+    fn join(&mut self) -> Result<()> {
+        Err(Error::new(task::ERROR_ID, task::ERROR_CODE_NOT_SUPPORTED))
     }
 }
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -41,7 +41,39 @@ pub trait Task {
     /// A `Result` indicating success or an `Error` if the execution fails.
     fn execute(&mut self) -> Result<()>;
 
+    /// Initiates an operation or task to be executed asynchronously in the background.
+    ///
+    /// This method dispatches the primary work to a separate thread, an asynchronous runtime,
+    /// or a similar background execution mechanism, allowing the current thread to continue
+    /// without blocking. The `&mut self` indicates that initiating the background task
+    /// may modify the internal state of the object, for example, to store a handle to
+    /// the spawned task, update status, or manage resources.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` if the background operation was successfully initiated. This indicates
+    ///   that the task was successfully handed off to the background execution system,
+    ///   but it does *not* guarantee the successful completion of the background task itself.
+    /// - `Err` if an error occurred while attempting to initiate or dispatch the
+    ///   background operation. This could be due to issues like failing to spawn a thread,
+    ///   the task executor being full, or other resource contention preventing the
+    ///   initiation.
     fn execute_in_background(&mut self) -> Result<()>;
 
+    /// Waits for the previously initiated background operation to complete.
+    ///
+    /// This method blocks the current thread until the background task, started by
+    /// `execute_in_background`, has finished its execution. After this method
+    /// returns successfully, the background task is considered completed, and
+    /// resources associated with it may be deallocated.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - There is no background operation currently running to join.
+    /// - The background operation itself encountered an unrecoverable error
+    ///   and this error is propagated to the join caller.
+    /// - An error occurred while waiting for the background operation to complete
+    ///   (e.g., an interruption or an internal communication error).
     fn join(&mut self) -> Result<()>;
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -40,4 +40,8 @@ pub trait Task {
     ///
     /// A `Result` indicating success or an `Error` if the execution fails.
     fn execute(&mut self) -> Result<()>;
+
+    fn execute_in_background(&mut self) -> Result<()>;
+
+    fn join(&mut self) -> Result<()>;
 }


### PR DESCRIPTION
Added backgrpund execution support for Task trait.
This closes #186.
